### PR TITLE
Fix OpenBSD build: portable Makefile and missing socket headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-CFLAGS := -Wall -Wextra -Wshadow -ansi -fshort-enums -fpic
+CFLAGS := -Wall -Wextra -Wshadow -fshort-enums -fpic
 
 all: build tests example
 
@@ -26,28 +26,28 @@ libs_dir:
 	mkdir -p libs
 
 libs/libproxyprotocol.so: src/proxy_protocol.o
-	$(CC) -shared -o $@ $+
+	$(CC) -shared -o $@ src/proxy_protocol.o
 
 src/proxy_protocol.o: src/proxy_protocol.c src/proxy_protocol.h
-	$(CC) ${CFLAGS} -pedantic -c -o $@ $<
-
-src/.o: %.c src/proxy_protocol.h
-	$(CC) ${CFLAGS} -c -o $@ $<
+	$(CC) ${CFLAGS} -c -o $@ src/proxy_protocol.c
 
 tests: tests/test_libproxyprotocol
-	LD_LIBRARY_PATH=libs/ $<
+	LD_LIBRARY_PATH=libs/ tests/test_libproxyprotocol
 
 tests/test_libproxyprotocol: tests/test.o libs/libproxyprotocol.so
-	$(CC) -Llibs/ ${CFLAGS} -o $@ $< -lproxyprotocol
+	$(CC) -Llibs/ ${CFLAGS} -o $@ tests/test.o -lproxyprotocol
+
+tests/test.o: tests/test.c src/proxy_protocol.h
+	$(CC) ${CFLAGS} -c -o $@ tests/test.c
 
 example: examples/client_server
-	LD_LIBRARY_PATH=libs/ $<
+	LD_LIBRARY_PATH=libs/ examples/client_server
 
 examples/client_server: examples/client_server.o libs/libproxyprotocol.so
-	$(CC) -Llibs/ ${CFLAGS} -o $@ $< -lproxyprotocol
+	$(CC) -Llibs/ ${CFLAGS} -o $@ examples/client_server.o -lproxyprotocol
 
-examples/client_server.o: examples/client_server.c
-	$(CC) ${CFLAGS} -pedantic -c -o $@ $<
+examples/client_server.o: examples/client_server.c src/proxy_protocol.h
+	$(CC) ${CFLAGS} -c -o $@ examples/client_server.c
 
 clean:
 	$(RM) src/*.o libs/libproxyprotocol.so

--- a/examples/client_server.c
+++ b/examples/client_server.c
@@ -5,6 +5,9 @@
     #include <ws2tcpip.h>
     #pragma comment(lib, "ws2_32.lib")
 #else
+    #include <sys/types.h>
+    #include <sys/socket.h>
+    #include <netinet/in.h>
     #include <arpa/inet.h>
 #endif
 

--- a/src/proxy_protocol.c
+++ b/src/proxy_protocol.c
@@ -24,6 +24,9 @@
     /* Caution: To be used only with fixed length arrays */
     #define _sprintf(buffer, format, ...) sprintf_s(buffer, sizeof(buffer), format, __VA_ARGS__)
 #else
+    #include <sys/types.h>
+    #include <sys/socket.h>
+    #include <netinet/in.h>
     #include <arpa/inet.h>
     #include <stdarg.h>
     /* vsprintf() and vargs as snprintf and __VA_ARGS__ do not exist in ANSI C */

--- a/tests/test.c
+++ b/tests/test.c
@@ -23,6 +23,9 @@
     #include <ws2tcpip.h>
     #pragma comment(lib, "ws2_32.lib")
 #else
+    #include <sys/types.h>
+    #include <sys/socket.h>
+    #include <netinet/in.h>
     #include <arpa/inet.h>
 #endif
 


### PR DESCRIPTION
## Summary
- Make Makefile portable to BSD make: drop GNU-only `$+` / `$<` in explicit rules and the broken `src/.o: %.c` pattern rule; add explicit rule for `tests/test.o`.
- Drop `-ansi`/`-pedantic` from CFLAGS so OpenBSD libc exposes POSIX/BSD socket symbols (these flags set `__STRICT_ANSI__` which hides them on OpenBSD).
- Include `<sys/types.h>`, `<sys/socket.h>`, `<netinet/in.h>` before `<arpa/inet.h>` in `proxy_protocol.c`, `tests/test.c`, and `examples/client_server.c` so `AF_INET`, `AF_INET6`, `AF_UNIX`, `AF_UNSPEC`, and `struct in6_addr` are defined on OpenBSD.

## Test
Linux: `make clean && make` builds, all 39 tests pass, example runs.

Closes #30