### PR TITLE
Fix out-of-bounds reads in TLV parsing and v1 header creation

### DIFF
--- a/src/proxy_protocol.c
+++ b/src/proxy_protocol.c
@@ -228,9 +228,15 @@ static uint8_t parse_port(const char *value, uint16_t *usport)
     return 1;
 }
 
-static pp2_tlv_t *tlv_new(uint8_t type, uint16_t length, const void *value)
+static pp2_tlv_t *tlv_new(uint8_t type, uint16_t length, uint16_t copy_length, const void *value)
 {
-    pp2_tlv_t *tlv = malloc(sizeof_pp2_tlv_t + length);
+    pp2_tlv_t *tlv;
+    /* Never copy more than the allocated length bytes */
+    if (copy_length > length)
+    {
+        copy_length = length;
+    }
+    tlv = malloc(sizeof_pp2_tlv_t + length);
     if (!tlv)
     {
         return NULL;
@@ -238,7 +244,7 @@ static pp2_tlv_t *tlv_new(uint8_t type, uint16_t length, const void *value)
     tlv->type = type;
     tlv->length_hi = length >> 8;
     tlv->length_lo = length & 0x00ff;
-    memcpy(tlv->value, value, length);
+    memcpy(tlv->value, value, copy_length);
     return tlv;
 }
 
@@ -274,7 +280,7 @@ static uint8_t tlv_array_append_tlv(tlv_array_t *tlv_array, pp2_tlv_t *tlv)
 
 static uint8_t tlv_array_append_tlv_new(tlv_array_t *tlv_array, uint8_t type, uint16_t length, const void *value)
 {
-    pp2_tlv_t *tlv = tlv_new(type, length, value);
+    pp2_tlv_t *tlv = tlv_new(type, length, length, value);
     if (!tlv)
     {
         return 0;
@@ -294,7 +300,8 @@ static uint8_t tlv_array_append_tlv_new_usascii(tlv_array_t *tlv_array, uint8_t 
     {
         return 0;
     }
-    tlv = tlv_new(type, length + 1, value);
+    /* Allocate length + 1 for the trailing NUL but copy only length bytes */
+    tlv = tlv_new(type, length + 1, length, value);
     if (!tlv)
     {
         return 0;
@@ -887,40 +894,49 @@ static uint8_t *pp1_create_hdr(const pp_info_t *pp_info, uint16_t *pp1_hdr_len, 
     }
     else if (pp_info->address_family == ADDR_FAMILY_INET || pp_info->address_family == ADDR_FAMILY_INET6)
     {
-        char src_addr[39+1];
-        char dst_addr[39+1];
+        char src_addr[INET6_ADDRSTRLEN];
+        char dst_addr[INET6_ADDRSTRLEN];
         const char *fam = pp_info->address_family == ADDR_FAMILY_INET ? "TCP4" : "TCP6";
-        if (pp_info->address_family == ADDR_FAMILY_INET)
+        int af = pp_info->address_family == ADDR_FAMILY_INET ? AF_INET : AF_INET6;
+        int written;
+        struct in6_addr src_bin, dst_bin;
+
+        if (inet_pton(af, pp_info->src_addr, &src_bin) != 1)
         {
-            struct in_addr in;
-            if (inet_pton(AF_INET, pp_info->src_addr, &in) != 1)
-            {
-                *error = -ERR_PP1_IPV4_SRC_IP;
-                return NULL;
-            }
-            if (inet_pton(AF_INET, pp_info->dst_addr, &in) != 1)
-            {
-                *error = -ERR_PP1_IPV4_DST_IP;
-                return NULL;
-            }
+            *error = af == AF_INET ? -ERR_PP1_IPV4_SRC_IP : -ERR_PP1_IPV6_SRC_IP;
+            return NULL;
         }
-        else if (pp_info->address_family == ADDR_FAMILY_INET6)
+        if (inet_pton(af, pp_info->dst_addr, &dst_bin) != 1)
         {
-            struct in6_addr in6;
-            if (inet_pton(AF_INET6, pp_info->src_addr, &in6) != 1)
-            {
-                *error = -ERR_PP1_IPV6_SRC_IP;
-                return NULL;
-            }
-            if (inet_pton(AF_INET6, pp_info->dst_addr, &in6) != 1)
-            {
-                *error = -ERR_PP1_IPV6_DST_IP;
-                return NULL;
-            }
+            *error = af == AF_INET ? -ERR_PP1_IPV4_DST_IP : -ERR_PP1_IPV6_DST_IP;
+            return NULL;
         }
-        memcpy(src_addr, pp_info->src_addr, sizeof(src_addr));
-        memcpy(dst_addr, pp_info->dst_addr, sizeof(dst_addr));
-        *pp1_hdr_len = (uint16_t)_sprintf(block, "PROXY %s %s %s %hu %hu"CRLF, fam, src_addr, dst_addr, pp_info->src_port, pp_info->dst_port);
+
+        /* Normalise via inet_ntop() so the textual form stays canonical (<= 39 chars) and within the PROXY v1 line limit */
+        if (!inet_ntop(af, &src_bin, src_addr, sizeof(src_addr)))
+        {
+            *error = af == AF_INET ? -ERR_PP1_IPV4_SRC_IP : -ERR_PP1_IPV6_SRC_IP;
+            return NULL;
+        }
+        if (!inet_ntop(af, &dst_bin, dst_addr, sizeof(dst_addr)))
+        {
+            *error = af == AF_INET ? -ERR_PP1_IPV4_DST_IP : -ERR_PP1_IPV6_DST_IP;
+            return NULL;
+        }
+
+        /* 27 = "PROXY " + "TCPx"(4) + 3 spaces + 2 ports(<=5) + "\r\n" + NUL */
+        if (strlen(src_addr) + strlen(dst_addr) + 27 > sizeof(block))
+        {
+            *error = -ERR_PP1_TRANSPORT_FAMILY;
+            return NULL;
+        }
+        written = _sprintf(block, "PROXY %s %s %s %hu %hu"CRLF, fam, src_addr, dst_addr, pp_info->src_port, pp_info->dst_port);
+        if (written <= 0 || (size_t)written >= sizeof(block))
+        {
+            *error = -ERR_PP1_TRANSPORT_FAMILY;
+            return NULL;
+        }
+        *pp1_hdr_len = (uint16_t)written;
     }
     else
     {

--- a/src/proxy_protocol.c
+++ b/src/proxy_protocol.c
@@ -228,23 +228,26 @@ static uint8_t parse_port(const char *value, uint16_t *usport)
     return 1;
 }
 
-static pp2_tlv_t *tlv_new(uint8_t type, uint16_t length, uint16_t copy_length, const void *value)
+static pp2_tlv_t *tlv_new(uint8_t type, uint16_t alloc_length, uint16_t value_length, const void *value)
 {
     pp2_tlv_t *tlv;
-    /* Never copy more than the allocated length bytes */
-    if (copy_length > length)
+    /* value_length is the on-wire TLV length; alloc_length may be larger so the
+     * caller can reserve extra bytes (US-ASCII TLVs add one for a trailing NUL
+     * that is not part of the value and must not be counted in the length field).
+     * Never store/copy more than what was allocated */
+    if (value_length > alloc_length)
     {
-        copy_length = length;
+        value_length = alloc_length;
     }
-    tlv = malloc(sizeof_pp2_tlv_t + length);
+    tlv = malloc(sizeof_pp2_tlv_t + alloc_length);
     if (!tlv)
     {
         return NULL;
     }
     tlv->type = type;
-    tlv->length_hi = length >> 8;
-    tlv->length_lo = length & 0x00ff;
-    memcpy(tlv->value, value, copy_length);
+    tlv->length_hi = value_length >> 8;
+    tlv->length_lo = value_length & 0x00ff;
+    memcpy(tlv->value, value, value_length);
     return tlv;
 }
 
@@ -300,7 +303,7 @@ static uint8_t tlv_array_append_tlv_new_usascii(tlv_array_t *tlv_array, uint8_t 
     {
         return 0;
     }
-    /* Allocate length + 1 for the trailing NUL but copy only length bytes */
+    /* Allocate length + 1 for the trailing NUL but the on-wire TLV length stays length */
     tlv = tlv_new(type, length + 1, length, value);
     if (!tlv)
     {
@@ -892,6 +895,16 @@ uint8_t *pp2_create_healthcheck_hdr(uint16_t *pp2_hdr_len, int32_t *error)
     return pp2_create_hdr(&pp_info, pp2_hdr_len, error);
 }
 
+/* Maps an address family + which-address (src/dst) to the matching v1 IP error */
+static int32_t pp1_ip_error(int af, int is_src)
+{
+    if (af == AF_INET)
+    {
+        return is_src ? -ERR_PP1_IPV4_SRC_IP : -ERR_PP1_IPV4_DST_IP;
+    }
+    return is_src ? -ERR_PP1_IPV6_SRC_IP : -ERR_PP1_IPV6_DST_IP;
+}
+
 static uint8_t *pp1_create_hdr(const pp_info_t *pp_info, uint16_t *pp1_hdr_len, int32_t *error)
 {
     char block[PP1_MAX_LENGTH];
@@ -920,24 +933,24 @@ static uint8_t *pp1_create_hdr(const pp_info_t *pp_info, uint16_t *pp1_hdr_len, 
 
         if (inet_pton(af, pp_info->src_addr, &src_bin) != 1)
         {
-            *error = af == AF_INET ? -ERR_PP1_IPV4_SRC_IP : -ERR_PP1_IPV6_SRC_IP;
+            *error = pp1_ip_error(af, 1);
             return NULL;
         }
         if (inet_pton(af, pp_info->dst_addr, &dst_bin) != 1)
         {
-            *error = af == AF_INET ? -ERR_PP1_IPV4_DST_IP : -ERR_PP1_IPV6_DST_IP;
+            *error = pp1_ip_error(af, 0);
             return NULL;
         }
 
         /* Normalise via inet_ntop() so the textual form stays canonical (<= 39 chars) and within the PROXY v1 line limit */
         if (!inet_ntop(af, &src_bin, src_addr, sizeof(src_addr)))
         {
-            *error = af == AF_INET ? -ERR_PP1_IPV4_SRC_IP : -ERR_PP1_IPV6_SRC_IP;
+            *error = pp1_ip_error(af, 1);
             return NULL;
         }
         if (!inet_ntop(af, &dst_bin, dst_addr, sizeof(dst_addr)))
         {
-            *error = af == AF_INET ? -ERR_PP1_IPV4_DST_IP : -ERR_PP1_IPV6_DST_IP;
+            *error = pp1_ip_error(af, 0);
             return NULL;
         }
 
@@ -947,8 +960,10 @@ static uint8_t *pp1_create_hdr(const pp_info_t *pp_info, uint16_t *pp1_hdr_len, 
             *error = -ERR_PP1_TRANSPORT_FAMILY;
             return NULL;
         }
+        /* The bound check above guarantees the line fits, so this only catches a
+         * _sprintf() error (vsprintf()/sprintf_s() return a negative value) */
         written = _sprintf(block, "PROXY %s %s %s %hu %hu"CRLF, fam, src_addr, dst_addr, pp_info->src_port, pp_info->dst_port);
-        if (written <= 0 || (size_t)written >= sizeof(block))
+        if (written <= 0)
         {
             *error = -ERR_PP1_TRANSPORT_FAMILY;
             return NULL;
@@ -1404,13 +1419,13 @@ static int32_t pp1_parse_hdr(const uint8_t *buffer, uint32_t buffer_length, pp_i
     src_address_end = strchr(ptr, ' ');
     if (!src_address_end)
     {
-        return sa_family == AF_INET ? -ERR_PP1_IPV4_SRC_IP : -ERR_PP1_IPV6_SRC_IP;
+        return pp1_ip_error(sa_family, 1);
     }
     src_address_length = (uint16_t)(src_address_end - ptr);
     memcpy(pp_info->src_addr, ptr, src_address_length);
     if (inet_pton(sa_family, pp_info->src_addr, &src_sin_addr) != 1)
     {
-        return sa_family == AF_INET ? -ERR_PP1_IPV4_SRC_IP : -ERR_PP1_IPV6_SRC_IP;
+        return pp1_ip_error(sa_family, 1);
     }
     ptr += src_address_length;
 
@@ -1425,13 +1440,13 @@ static int32_t pp1_parse_hdr(const uint8_t *buffer, uint32_t buffer_length, pp_i
     dst_address_end = strchr(ptr, ' ');
     if (!dst_address_end)
     {
-        return sa_family == AF_INET ? -ERR_PP1_IPV4_DST_IP : -ERR_PP1_IPV6_DST_IP;
+        return pp1_ip_error(sa_family, 0);
     }
     dst_address_length = (uint16_t)(dst_address_end - ptr);
     memcpy(pp_info->dst_addr, ptr, dst_address_length);
     if (inet_pton(sa_family, pp_info->dst_addr, &dst_sin_addr) != 1)
     {
-        return sa_family == AF_INET ? -ERR_PP1_IPV4_DST_IP : -ERR_PP1_IPV6_DST_IP;
+        return pp1_ip_error(sa_family, 0);
     }
     ptr += dst_address_length;
 

--- a/src/proxy_protocol.c
+++ b/src/proxy_protocol.c
@@ -799,20 +799,37 @@ static uint8_t *pp2_create_hdr(const pp_info_t *pp_info, uint16_t *pp2_hdr_len, 
         return NULL;
     }
     *pp2_hdr_len = (uint16_t)(sizeof(proxy_hdr_v2_t) + len);
+    /* Cap at 15: a header length is a uint16_t, so a larger power would
+     * overflow the 1 << power shift (1 << 16 wraps to 0 -> division by zero,
+     * 1 << 31 is signed overflow) and could never fit the header anyway */
+    if (pp_info->pp2_info.alignment_power > 15)
+    {
+        *error = -ERR_PP2_LENGTH;
+        return NULL;
+    }
     if (pp_info->pp2_info.alignment_power > 1)
     {
         uint16_t alignment = 1 << pp_info->pp2_info.alignment_power;
         if (*pp2_hdr_len % alignment)
         {
-            uint16_t pp2_hdr_len_padded = (*pp2_hdr_len / alignment + 1) * alignment;
+            /* Compute the padded length in a wider type: the next multiple of
+             * alignment can be 65536 (e.g. power 15 with a header > 32768, or any
+             * power when the header is close to UINT16_MAX), which would wrap to 0
+             * in a uint16_t and drive an undersized malloc -> heap overflow */
+            uint32_t pp2_hdr_len_padded = (*pp2_hdr_len / alignment + 1) * alignment;
             /* The NOOP TLV needs to be at least 3 bytes because a TLV can not be smaller than that */
             if (pp2_hdr_len_padded - *pp2_hdr_len < sizeof_pp2_tlv_t)
             {
                 pp2_hdr_len_padded += alignment;
             }
-            padding_bytes = pp2_hdr_len_padded - (uint16_t)sizeof(proxy_hdr_v2_t) - (uint16_t)len - sizeof_pp2_tlv_t;
+            if (pp2_hdr_len_padded > UINT16_MAX)
+            {
+                *error = -ERR_PP2_LENGTH;
+                return NULL;
+            }
+            padding_bytes = (uint16_t)(pp2_hdr_len_padded - sizeof(proxy_hdr_v2_t) - len - sizeof_pp2_tlv_t);
 
-            *pp2_hdr_len = pp2_hdr_len_padded;
+            *pp2_hdr_len = (uint16_t)pp2_hdr_len_padded;
             len = pp2_hdr_len_padded - (uint32_t)sizeof(proxy_hdr_v2_t);
         }
     }

--- a/src/proxy_protocol.c
+++ b/src/proxy_protocol.c
@@ -812,7 +812,7 @@ static uint8_t *pp2_create_hdr(const pp_info_t *pp_info, uint16_t *pp2_hdr_len, 
     }
     if (pp_info->pp2_info.alignment_power > 1)
     {
-        uint16_t alignment = 1 << pp_info->pp2_info.alignment_power;
+        uint16_t alignment = 1U << pp_info->pp2_info.alignment_power;
         if (*pp2_hdr_len % alignment)
         {
             /* Compute the padded length in a wider type: the next multiple of

--- a/src/proxy_protocol.c
+++ b/src/proxy_protocol.c
@@ -941,7 +941,7 @@ static uint8_t *pp1_create_hdr(const pp_info_t *pp_info, uint16_t *pp1_hdr_len, 
             return NULL;
         }
 
-        /* 27 = "PROXY " + "TCPx"(4) + 3 spaces + 2 ports(<=5) + "\r\n" + NUL */
+        /* 27 = "PROXY " + "TCPx"(4) + 4 spaces + 2 ports(<=5) + "\r\n" + NUL */
         if (strlen(src_addr) + strlen(dst_addr) + 27 > sizeof(block))
         {
             *error = -ERR_PP1_TRANSPORT_FAMILY;

--- a/src/proxy_protocol.c
+++ b/src/proxy_protocol.c
@@ -239,6 +239,10 @@ static pp2_tlv_t *tlv_new(uint8_t type, uint16_t alloc_length, uint16_t value_le
     {
         value_length = alloc_length;
     }
+    if (value == NULL && value_length > 0)
+    {
+        return NULL;
+    }
     tlv = malloc(sizeof_pp2_tlv_t + alloc_length);
     if (!tlv)
     {
@@ -247,7 +251,10 @@ static pp2_tlv_t *tlv_new(uint8_t type, uint16_t alloc_length, uint16_t value_le
     tlv->type = type;
     tlv->length_hi = value_length >> 8;
     tlv->length_lo = value_length & 0x00ff;
-    memcpy(tlv->value, value, value_length);
+    if (value_length > 0)
+    {
+        memcpy(tlv->value, value, value_length);
+    }
     return tlv;
 }
 
@@ -715,6 +722,7 @@ static uint8_t *pp2_create_hdr(const pp_info_t *pp_info, uint16_t *pp2_hdr_len, 
 {
     proxy_hdr_v2_t proxy_hdr_v2 = { PP2_SIG, '\x21', 0, 0 };
     uint16_t proxy_addr_len, padding_bytes, index;
+    uint8_t padding_applied;
     uint32_t len;
     proxy_addr_t proxy_addr;
     const tlv_array_t *tlv_array;
@@ -787,6 +795,7 @@ static uint8_t *pp2_create_hdr(const pp_info_t *pp_info, uint16_t *pp2_hdr_len, 
     len = proxy_addr_len;
     tlv_array = &pp_info->pp2_info.tlv_array;
     padding_bytes = 0;
+    padding_applied = 0;
     for (i = 0; i < tlv_array->len; i++)
     {
         uint16_t tlv_len = sizeof_pp2_tlv_t + (tlv_array->tlvs[i]->length_hi << 8 | tlv_array->tlvs[i]->length_lo);
@@ -812,14 +821,14 @@ static uint8_t *pp2_create_hdr(const pp_info_t *pp_info, uint16_t *pp2_hdr_len, 
     }
     if (pp_info->pp2_info.alignment_power > 1)
     {
-        uint16_t alignment = 1U << pp_info->pp2_info.alignment_power;
+        uint16_t alignment = (uint16_t)(1U << pp_info->pp2_info.alignment_power);
         if (*pp2_hdr_len % alignment)
         {
             /* Compute the padded length in a wider type: the next multiple of
              * alignment can be 65536 (e.g. power 15 with a header > 32768, or any
              * power when the header is close to UINT16_MAX), which would wrap to 0
              * in a uint16_t and drive an undersized malloc -> heap overflow */
-            uint32_t pp2_hdr_len_padded = (*pp2_hdr_len / alignment + 1) * alignment;
+            uint32_t pp2_hdr_len_padded = (((uint32_t)*pp2_hdr_len / (uint32_t)alignment) + 1U) * (uint32_t)alignment;
             /* The NOOP TLV needs to be at least 3 bytes because a TLV can not be smaller than that */
             if (pp2_hdr_len_padded - *pp2_hdr_len < sizeof_pp2_tlv_t)
             {
@@ -831,6 +840,7 @@ static uint8_t *pp2_create_hdr(const pp_info_t *pp_info, uint16_t *pp2_hdr_len, 
                 return NULL;
             }
             padding_bytes = (uint16_t)(pp2_hdr_len_padded - sizeof(proxy_hdr_v2_t) - len - sizeof_pp2_tlv_t);
+            padding_applied = 1;
 
             *pp2_hdr_len = (uint16_t)pp2_hdr_len_padded;
             len = pp2_hdr_len_padded - (uint32_t)sizeof(proxy_hdr_v2_t);
@@ -858,7 +868,7 @@ static uint8_t *pp2_create_hdr(const pp_info_t *pp_info, uint16_t *pp2_hdr_len, 
         memcpy(pp2_hdr + index, tlv_array->tlvs[i], tlv_len);
         index += tlv_len;
     }
-    if (pp_info->pp2_info.alignment_power > 1 && padding_bytes > 0)
+    if (padding_applied)
     {
         pp2_tlv_t tlv = { 0 };
         tlv.type = PP2_TYPE_NOOP;
@@ -942,7 +952,9 @@ static uint8_t *pp1_create_hdr(const pp_info_t *pp_info, uint16_t *pp1_hdr_len, 
             return NULL;
         }
 
-        /* Normalise via inet_ntop() so the textual form stays canonical (<= 39 chars) and within the PROXY v1 line limit */
+        /* Normalise via inet_ntop(): regardless of the input length, the
+         * canonical output is at most 39 chars (full IPv6 hextet form), keeping
+         * the line within the PROXY v1 limit */
         if (!inet_ntop(af, &src_bin, src_addr, sizeof(src_addr)))
         {
             *error = pp1_ip_error(af, 1);
@@ -954,10 +966,13 @@ static uint8_t *pp1_create_hdr(const pp_info_t *pp_info, uint16_t *pp1_hdr_len, 
             return NULL;
         }
 
-        /* 27 = "PROXY " + "TCPx"(4) + 4 spaces + 2 ports(<=5) + "\r\n" + NUL */
+        /* 27 = "PROXY " + "TCPx"(4) + 4 spaces + 2 ports(<=5) + "\r\n" + NUL.
+         * Canonical inet_ntop() output is <= 39 chars each, so this always fits;
+         * the runtime guard stays because _sprintf() is an unbounded vsprintf()
+         * on ANSI C targets (no snprintf() in C89) */
         if (strlen(src_addr) + strlen(dst_addr) + 27 > sizeof(block))
         {
-            *error = -ERR_PP1_TRANSPORT_FAMILY;
+            *error = -ERR_HEAP_ALLOC;
             return NULL;
         }
         /* The bound check above guarantees the line fits, so this only catches a
@@ -965,7 +980,7 @@ static uint8_t *pp1_create_hdr(const pp_info_t *pp_info, uint16_t *pp1_hdr_len, 
         written = _sprintf(block, "PROXY %s %s %s %hu %hu"CRLF, fam, src_addr, dst_addr, pp_info->src_port, pp_info->dst_port);
         if (written <= 0)
         {
-            *error = -ERR_PP1_TRANSPORT_FAMILY;
+            *error = -ERR_HEAP_ALLOC;
             return NULL;
         }
         *pp1_hdr_len = (uint16_t)written;

--- a/tests/test.c
+++ b/tests/test.c
@@ -1057,7 +1057,7 @@ int main(void)
         else
         {
             uint16_t pp_hdr_len = 0;
-            uint16_t alignment = 1U << tests[i].pp_info_in.pp2_info.alignment_power;
+            uint16_t alignment = (uint16_t)(1U << tests[i].pp_info_in.pp2_info.alignment_power);
             int32_t error = ERR_NULL;
             uint8_t *pp_hdr = NULL;
 
@@ -1220,7 +1220,7 @@ int main(void)
     {
         unsigned char powers[] = { 16, 31, 255 };
         size_t k;
-        for (k = 0; k < sizeof(powers); k++)
+        for (k = 0; k < NUM_ELEMS(powers); k++)
         {
             pp_info_t pp_info = { 0 };
             uint16_t pp_hdr_len = 0;

--- a/tests/test.c
+++ b/tests/test.c
@@ -1222,6 +1222,92 @@ int main(void)
     }
     printf("PASSED\n");
 
+    /* Regression: alignment_power >= 16 used to make 1 << power overflow the
+     * uint16_t alignment (division by zero / signed overflow). It must now be
+     * rejected with -ERR_PP2_LENGTH instead of crashing. */
+    printf("Running test: pp_create_hdr rejects oversized alignment_power...");
+    {
+        unsigned char powers[] = { 16, 31, 255 };
+        size_t k;
+        for (k = 0; k < sizeof(powers); k++)
+        {
+            pp_info_t pp_info = { 0 };
+            uint16_t pp_hdr_len = 0;
+            int32_t error = ERR_NULL;
+            uint8_t *pp_hdr;
+            pp_info.address_family = ADDR_FAMILY_INET;
+            pp_info.transport_protocol = TRANSPORT_PROTOCOL_STREAM;
+            strcpy(pp_info.src_addr, "1.2.3.4");
+            strcpy(pp_info.dst_addr, "5.6.7.8");
+            pp_info.src_port = 80;
+            pp_info.dst_port = 443;
+            pp_info.pp2_info.alignment_power = powers[k];
+            pp_hdr = pp_create_hdr(2, &pp_info, &pp_hdr_len, &error);
+            if (pp_hdr || error != -ERR_PP2_LENGTH)
+            {
+                printf("FAILED\n");
+                free(pp_hdr);
+                pp_info_clear(&pp_info);
+                return EXIT_FAILURE;
+            }
+            pp_info_clear(&pp_info);
+        }
+    }
+    printf("PASSED\n");
+
+    /* Regression: a large TLV makes the padded header length round up to the
+     * next multiple of alignment, which can hit 65536 and wrap to 0 in the old
+     * uint16_t computation -> undersized malloc + heap overflow on TLV copy.
+     * Both a small alignment_power (next multiple just above UINT16_MAX) and
+     * power 15 (header > 32768) reach the wrap. It must now be rejected. */
+    printf("Running test: pp_create_hdr rejects alignment padding overflow...");
+    {
+        struct { uint16_t value_len; unsigned char power; } cases[] = {
+            { 65514, 2 },
+            { 40000, 15 }
+        };
+        size_t k;
+        for (k = 0; k < sizeof(cases) / sizeof(cases[0]); k++)
+        {
+            pp_info_t pp_info = { 0 };
+            uint16_t pp_hdr_len = 0;
+            int32_t error = ERR_NULL;
+            uint8_t *pp_hdr;
+            uint8_t *host_name = malloc(cases[k].value_len);
+            if (!host_name)
+            {
+                printf("FAILED\n");
+                return EXIT_FAILURE;
+            }
+            memset(host_name, 'a', cases[k].value_len);
+            pp_info.address_family = ADDR_FAMILY_INET;
+            pp_info.transport_protocol = TRANSPORT_PROTOCOL_STREAM;
+            strcpy(pp_info.src_addr, "1.2.3.4");
+            strcpy(pp_info.dst_addr, "5.6.7.8");
+            pp_info.src_port = 80;
+            pp_info.dst_port = 443;
+            pp_info.pp2_info.alignment_power = cases[k].power;
+            if (!pp_info_add_authority(&pp_info, cases[k].value_len, host_name))
+            {
+                printf("FAILED\n");
+                free(host_name);
+                pp_info_clear(&pp_info);
+                return EXIT_FAILURE;
+            }
+            free(host_name);
+            pp_hdr = pp_create_hdr(2, &pp_info, &pp_hdr_len, &error);
+            if (pp_hdr || error != -ERR_PP2_LENGTH)
+            {
+                printf("FAILED\n");
+                free(pp_hdr);
+                pp_info_clear(&pp_info);
+                return EXIT_FAILURE;
+            }
+            pp_info_clear(&pp_info);
+        }
+    }
+    printf("PASSED\n");
+
     printf("All tests completed successfully\n");
     return EXIT_SUCCESS;
 }

--- a/tests/test.c
+++ b/tests/test.c
@@ -1057,7 +1057,7 @@ int main(void)
         else
         {
             uint16_t pp_hdr_len = 0;
-            uint16_t alignment = 1 << tests[i].pp_info_in.pp2_info.alignment_power;
+            uint16_t alignment = 1U << tests[i].pp_info_in.pp2_info.alignment_power;
             int32_t error = ERR_NULL;
             uint8_t *pp_hdr = NULL;
 

--- a/tests/test.c
+++ b/tests/test.c
@@ -482,7 +482,7 @@ int main(void)
                 {
                     .type = PP2_TYPE_AWS,
                     .subtype = PP2_SUBTYPE_AWS_VPCE_ID,
-                    .value_len = 23,
+                    .value_len = 22,
                     .value = (const uint8_t*) "vpce-23d8ezjk38bchilm4"
                 },
             },
@@ -586,7 +586,7 @@ int main(void)
             .add_tlvs = {
                 {
                 .type = PP2_SUBTYPE_SSL_VERSION,
-                    .value_len = 8,
+                    .value_len = 7,
                     .value = (const uint8_t*) "TLSv1.2"
                 },
                 {
@@ -596,23 +596,23 @@ int main(void)
                 },
                 {
                     .type = PP2_SUBTYPE_SSL_CIPHER,
-                    .value_len = 28,
+                    .value_len = 27,
                     .value = (const uint8_t*) "ECDHE-RSA-AES128-GCM-SHA256"
                 },
                 {
                     .type = PP2_SUBTYPE_SSL_SIG_ALG,
-                    .value_len = 7,
+                    .value_len = 6,
                     .value = (const uint8_t*) "SHA256"
                 },
                 {
                     .type = PP2_SUBTYPE_SSL_KEY_ALG,
-                    .value_len = 8,
+                    .value_len = 7,
                     .value = (const uint8_t*) "RSA2048"
                 },
                 {
                     .type = PP2_TYPE_AWS,
                     .subtype = PP2_SUBTYPE_AWS_VPCE_ID,
-                    .value_len = 24,
+                    .value_len = 23,
                     .value = (const uint8_t*) "vpce-24d8ezjk38bchilm4m"
                 },
                 {
@@ -648,7 +648,7 @@ int main(void)
             .expected_tlvs = {
                 {
                     .type = PP2_SUBTYPE_SSL_VERSION,
-                    .value_len = 8,
+                    .value_len = 7,
                     .value = (const uint8_t*) "TLSv1.2"
                 },
                 {
@@ -658,17 +658,17 @@ int main(void)
                 },
                 {
                     .type = PP2_SUBTYPE_SSL_CIPHER,
-                    .value_len = 28,
+                    .value_len = 27,
                     .value = (const uint8_t*) "ECDHE-RSA-AES128-GCM-SHA256"
                 },
                 {
                     .type = PP2_SUBTYPE_SSL_SIG_ALG,
-                    .value_len = 7,
+                    .value_len = 6,
                     .value = (const uint8_t*) "SHA256"
                 },
                 {
                     .type = PP2_SUBTYPE_SSL_KEY_ALG,
-                    .value_len = 8,
+                    .value_len = 7,
                     .value = (const uint8_t*) "RSA2048"
                 },
             },
@@ -699,7 +699,7 @@ int main(void)
             .add_tlvs = {
                 {
                     .type = PP2_SUBTYPE_SSL_VERSION,
-                    .value_len = 8,
+                    .value_len = 7,
                     .value = (const uint8_t*) "TLSv1.3"
                 },
                 {
@@ -709,27 +709,27 @@ int main(void)
                 },
                 {
                     .type = PP2_SUBTYPE_SSL_CIPHER,
-                    .value_len = 23,
+                    .value_len = 22,
                     .value = (const uint8_t*) "TLS_AES_256_GCM_SHA384"
                 },
                 {
                     .type = PP2_SUBTYPE_SSL_SIG_ALG,
-                    .value_len = 7,
+                    .value_len = 6,
                     .value = (const uint8_t*) "SHA384"
                 },
                 {
                     .type = PP2_SUBTYPE_SSL_KEY_ALG,
-                    .value_len = 8,
+                    .value_len = 7,
                     .value = (const uint8_t*) "RSA4096"
                 },
                 {
                     .type = PP2_SUBTYPE_SSL_GROUP,
-                    .value_len = 10,
+                    .value_len = 9,
                     .value = (const uint8_t*) "secp256r1"
                 },
                 {
                     .type = PP2_SUBTYPE_SSL_SIG_SCHEME,
-                    .value_len = 20,
+                    .value_len = 19,
                     .value = (const uint8_t*) "rsa_pss_rsae_sha256"
                 },
                 {
@@ -773,7 +773,7 @@ int main(void)
                 },
                 {
                     .type = PP2_TYPE_NETNS,
-                    .value_len = 8,
+                    .value_len = 7,
                     .value = (const uint8_t*) "mynetns"
                 },
                 {
@@ -1029,7 +1029,7 @@ int main(void)
                 .dst_port = 8080,
             },
             .expected_tlvs = {
-                { .type = PP2_TYPE_NETNS, .value_len = 2, .value = (const uint8_t*) "A" },
+                { .type = PP2_TYPE_NETNS, .value_len = 1, .value = (const uint8_t*) "A" },
             },
         },
     };
@@ -1172,24 +1172,15 @@ int main(void)
     {
         const char *mixed_src = "ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255";
         const char *mixed_dst = "1111:2222:3333:4444:5555:6666:127.0.0.1";
-        char norm_src[INET6_ADDRSTRLEN] = { 0 };
-        char norm_dst[INET6_ADDRSTRLEN] = { 0 };
-        struct in6_addr bin;
+        /* RFC 5952 canonical forms the library must normalise the inputs to */
+        const char *norm_src = "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff";
+        const char *norm_dst = "1111:2222:3333:4444:5555:6666:7f00:1";
         pp_info_t pp_info_in = { 0 };
         pp_info_t pp_info_out = { 0 };
         uint16_t pp_hdr_len = 0;
         int32_t error = ERR_NULL;
         uint8_t *pp_hdr = NULL;
         int32_t parse_rc;
-
-        if (inet_pton(AF_INET6, mixed_src, &bin) != 1
-            || !inet_ntop(AF_INET6, &bin, norm_src, sizeof(norm_src))
-            || inet_pton(AF_INET6, mixed_dst, &bin) != 1
-            || !inet_ntop(AF_INET6, &bin, norm_dst, sizeof(norm_dst)))
-        {
-            printf("FAILED\n");
-            return EXIT_FAILURE;
-        }
 
         pp_info_in.address_family = ADDR_FAMILY_INET6;
         pp_info_in.transport_protocol = TRANSPORT_PROTOCOL_STREAM;
@@ -1263,7 +1254,7 @@ int main(void)
     printf("Running test: pp_create_hdr rejects alignment padding overflow...");
     {
         struct { uint16_t value_len; unsigned char power; } cases[] = {
-            { 65514, 2 },
+            { 65504, 2 },
             { 40000, 15 }
         };
         size_t k;

--- a/tests/test.c
+++ b/tests/test.c
@@ -218,6 +218,20 @@ uint8_t pp2_hdr_ssl_trailing_bytes[] = {
             0xff, 0xff,             /* 2 trailing orphan bytes (not a valid sub-TLV header) */
 };
 
+/* v2 header whose last TLV is a US-ASCII NETNS TLV occupying the final byte of
+ * the buffer (regression for the 1-byte OOB read while parsing US-ASCII TLVs) */
+uint8_t pp2_hdr_usascii_tlv_at_end[] = {
+            0x0d, 0x0a, 0x0d, 0x0a, /* Start of v2 signature */
+            0x00, 0x0d, 0x0a, 0x51,
+            0x55, 0x49, 0x54, 0x0a, /* End of v2 signature */
+            0x21, 0x11, 0x00, 0x10, /* ver_cmd, fam and len (16) */
+            0xc0, 0xa8, 0x0a, 0x64, /* Source IP */
+            0xc0, 0xa8, 0x0b, 0x5a, /* Destination IP */
+            0xa5, 0x5c, 0x1f, 0x90, /* Source port, Destination port */
+            0x30, 0x00, 0x01,       /* PP2_TYPE_NETNS TLV with length 1 */
+            0x41,                   /* "A" - last byte of the buffer */
+};
+
 static uint8_t pp_add_tlvs(pp_info_t *pp_info, const test_tlv_t (*add_tlvs)[10])
 {
     uint8_t i;
@@ -1001,6 +1015,23 @@ int main(void)
                 .src_port = 80,
             },
         },
+        {
+            .name = "v2 PROXY protocol header: US-ASCII TLV at end of buffer (no OOB read)",
+            .raw_bytes_in = pp2_hdr_usascii_tlv_at_end,
+            .raw_bytes_in_length = sizeof(pp2_hdr_usascii_tlv_at_end),
+            .rc_expected = sizeof(pp2_hdr_usascii_tlv_at_end),
+            .pp_info_out_expected = {
+                .address_family = ADDR_FAMILY_INET,
+                .transport_protocol = TRANSPORT_PROTOCOL_STREAM,
+                .src_addr = "192.168.10.100",
+                .dst_addr = "192.168.11.90",
+                .src_port = 42332,
+                .dst_port = 8080,
+            },
+            .expected_tlvs = {
+                { .type = PP2_TYPE_NETNS, .value_len = 2, .value = (const uint8_t*) "A" },
+            },
+        },
     };
 
     /* Run tests */
@@ -1132,6 +1163,62 @@ int main(void)
     {
         printf("FAILED\n");
         return EXIT_FAILURE;
+    }
+    printf("PASSED\n");
+
+    /* Regression: v1 create from a 45-char IPv4-mapped IPv6 address used to
+     * overflow the line buffer; it must now succeed and round-trip */
+    printf("Running test: v1 create with 45-char IPv4-mapped IPv6 addresses...");
+    {
+        const char *mixed_src = "ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255";
+        const char *mixed_dst = "1111:2222:3333:4444:5555:6666:127.0.0.1";
+        char norm_src[INET6_ADDRSTRLEN] = { 0 };
+        char norm_dst[INET6_ADDRSTRLEN] = { 0 };
+        struct in6_addr bin;
+        pp_info_t pp_info_in = { 0 };
+        pp_info_t pp_info_out = { 0 };
+        uint16_t pp_hdr_len = 0;
+        int32_t error = ERR_NULL;
+        uint8_t *pp_hdr = NULL;
+        int32_t parse_rc;
+
+        if (inet_pton(AF_INET6, mixed_src, &bin) != 1
+            || !inet_ntop(AF_INET6, &bin, norm_src, sizeof(norm_src))
+            || inet_pton(AF_INET6, mixed_dst, &bin) != 1
+            || !inet_ntop(AF_INET6, &bin, norm_dst, sizeof(norm_dst)))
+        {
+            printf("FAILED\n");
+            return EXIT_FAILURE;
+        }
+
+        pp_info_in.address_family = ADDR_FAMILY_INET6;
+        pp_info_in.transport_protocol = TRANSPORT_PROTOCOL_STREAM;
+        strcpy(pp_info_in.src_addr, mixed_src);
+        strcpy(pp_info_in.dst_addr, mixed_dst);
+        pp_info_in.src_port = 65535;
+        pp_info_in.dst_port = 65535;
+
+        pp_hdr = pp_create_hdr(1, &pp_info_in, &pp_hdr_len, &error);
+        if (!pp_hdr || error != ERR_NULL)
+        {
+            printf("FAILED\n");
+            return EXIT_FAILURE;
+        }
+        parse_rc = pp_parse_hdr(pp_hdr, pp_hdr_len, &pp_info_out);
+        if (parse_rc != pp_hdr_len
+            || pp_info_out.address_family != ADDR_FAMILY_INET6
+            || pp_info_out.src_port != 65535
+            || pp_info_out.dst_port != 65535
+            || strcmp(pp_info_out.src_addr, norm_src)
+            || strcmp(pp_info_out.dst_addr, norm_dst))
+        {
+            printf("FAILED\n");
+            pp_info_clear(&pp_info_out);
+            free(pp_hdr);
+            return EXIT_FAILURE;
+        }
+        pp_info_clear(&pp_info_out);
+        free(pp_hdr);
     }
     printf("PASSED\n");
 


### PR DESCRIPTION
Fixes four memory-safety / robustness bugs found with AddressSanitizer + UBSan (some via fuzzing the create path):

1. **Parsing (`pp_parse_hdr`)** — a US-ASCII TLV (e.g. NETNS, SSL sub-TLVs) copied `length + 1` bytes from its value, reading one byte past the input buffer when the TLV was the last thing in the buffer. `tlv_new()` now takes a separate copy length so it allocates `length + 1` for the trailing NUL but copies only `length` bytes. Reachable from a crafted network header.

2. **Parsing (US-ASCII TLV length inflation)** — the trailing NUL added for the getters was also written into the on-wire `length` field, so parsed US-ASCII TLVs reported a `length` one byte too big and, on re-serialisation, emitted the NUL on the wire and grew the header — inflation that compounded by one byte on every parse → create hop. The stored length is now the true value length (NUL no longer counted), matching the documented getter contract; the buffer stays NUL-terminated.

3. **Creating (`pp_create_hdr`, v1)** — addresses were copied into fixed 40-byte buffers and `sprintf`'d. A 45-char IPv4-mapped IPv6 address (e.g. `ffff:...:255.255.255.255`) overflowed those buffers and the line buffer, and produced a header too long for the v1 parser to read back. Addresses are now normalised via `inet_ntop()` to the canonical (<=39-char) form; the line length is bounded before formatting (the non-Windows `_sprintf` uses unbounded `vsprintf`, as ANSI C has no `snprintf`) and the `_sprintf` return value is validated so a `sprintf_s` failure on Windows cannot drive an oversized `malloc`/`memcpy`.

4. **Creating (`pp_create_hdr`, v2 alignment)** — `pp2_info.alignment_power` is a caller-set `uint8_t`. Values >= 16 made `1 << alignment_power` overflow the `uint16_t` alignment (`1 << 16` wraps to 0 → division by zero; `1 << 31` is signed-integer overflow). Separately, rounding the header length up to the alignment could exceed `UINT16_MAX` even for an in-range power, wrapping the `uint16_t` padded length to a tiny value and driving an undersized `malloc` followed by a TLV `memcpy` past the allocation (heap overflow, confirmed under ASan with `alignment_power = 12`). The power is now capped at 15 and the padded length is computed in a wider type and rejected with `-ERR_PP2_LENGTH` if it would exceed `UINT16_MAX`.

Also tidied the v1 header code: the repeated family → IP-error-code ternary is now a small helper, the redundant post-`sprintf` bound check was dropped (the length is already bounded before formatting), and the v1 IPv4-mapped IPv6 regression asserts against hard-coded RFC 5952 canonical literals instead of recomputing them with the same `inet_pton`/`inet_ntop` calls under test.

Added regression tests for all of the above; the full suite passes under ASan/UBSan and the library compiles clean under `-std=c89 -pedantic-errors`.